### PR TITLE
Add support for query parameters matching to RouteVoter

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,9 +54,9 @@ jobs:
               uses: actions/checkout@v2
             - name: Cache
               uses: actions/cache@v2
-              with: 
+              with:
                   path: ~/.composer/cache/files
-                  key: composer-${{ matrix.php }}-${{ matrix.symfony }}-${{ matrix.composer_option }} 
+                  key: composer-${{ matrix.php }}-${{ matrix.symfony }}-${{ matrix.composer_option }}
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
@@ -67,5 +67,5 @@ jobs:
             - run: composer config minimum-stability dev && composer config prefer-stable true
               if: matrix.dev
             - run: composer update --no-interaction --no-progress --ansi ${{ matrix.composer_option }}
-            - run: vendor/bin/simple-phpunit
+            - run: vendor/bin/phpunit
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,6 +50,9 @@ jobs:
                     - description: 'Symfony 5.4'
                       php: '7.4'
                       symfony: 5.4.x-dev
+                    - description: 'Symfony 6.0'
+                      php: '8.0'
+                      symfony: 6.0.x-dev
                     - description: 'Dev deps'
                       php: '8.0'
                       dev: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,6 +34,8 @@ jobs:
                       php: '7.4'
                     - description: 'No Symfony specified'
                       php: '8.0'
+                    - description: 'No Symfony specified'
+                      php: '8.1'
                     - description: 'Lowest deps'
                       php: '7.3'
                       composer_option: '--prefer-lowest'
@@ -45,6 +47,9 @@ jobs:
                     - description: 'Symfony 5.3'
                       php: '7.4'
                       symfony: 5.3.*
+                    - description: 'Symfony 5.4'
+                      php: '7.4'
+                      symfony: 5.4.x-dev
                     - description: 'Dev deps'
                       php: '8.0'
                       dev: true

--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,9 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "psr/container": "^1.0",
-        "symfony/http-foundation": "^4.4 || ^5.0",
+        "symfony/http-foundation": "^4.4 || ^5.0 || ^6.0",
         "symfony/phpunit-bridge": "^5.3",
-        "symfony/routing": "^4.4 || ^5.0",
+        "symfony/routing": "^4.4 || ^5.0 || ^6.0",
         "twig/twig": "^1.40 || ^2.9 || ^3.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "twig/twig": "<1.40 || >=2,<2.9"
     },
     "require-dev": {
-        "phpspec/prophecy": "^1.13",
+        "phpunit/phpunit": "^9.5",
         "psr/container": "^1.0",
         "symfony/http-foundation": "^4.4 || ^5.0",
         "symfony/phpunit-bridge": "^5.3",

--- a/doc/01-Basic-Menus.md
+++ b/doc/01-Basic-Menus.md
@@ -91,7 +91,7 @@ templates. Or you can provide your own implementation of the `RendererInterface`
 Working with your menu tree
 ---------------------------
 
-Your menu tree works and acts like a multi-dimensional array. Specifically,
+Your menu tree works and acts like a multidimensional array. Specifically,
 it implements ArrayAccess, Countable and Iterator:
 
 ```php
@@ -261,7 +261,7 @@ the `li` around that item, as well as a `current_ancestor` around any of
 its parent `li` elements. This state can either be forced on the item by
 setting it explicitly or matched using several voters.
 
-By default, the current item is rendered as link too. You can make the current
+By default, the current item is rendered as a link too. You can make the current
 item not a link by setting the `currentAsLink` option to false. The ListRenderer
 then renders the item with a `<span>` tag instead of an `<a>`.
 

--- a/doc/02-Twig-Integration.md
+++ b/doc/02-Twig-Integration.md
@@ -234,7 +234,7 @@ $itemMatcher = new \Knp\Menu\Matcher\Matcher();
 $menuRenderer = new \Knp\Menu\Renderer\TwigRenderer($twig, 'knp_menu.html.twig', $itemMatcher);
 ```
 
-This works just like any other renderer, and will output an un-ordered list
+This works just like any other renderer, and will output an unordered list
 of menu items (e.g. `ul` and `li` elements):
 
 ```php

--- a/doc/05-Matcher.md
+++ b/doc/05-Matcher.md
@@ -13,8 +13,7 @@ Here is an example how to use the matcher:
 ```php
 use Knp\Menu\Matcher\Matcher;
 
-$itemMatcher = new Matcher();
-$itemMatcher->addVoter(new UriVoter(str_replace('/index.php', '', $_SERVER['REQUEST_URI'])));
+$itemMatcher = new Matcher([new UriVoter(str_replace('/index.php', '', $_SERVER['REQUEST_URI']))]);
 ```
 
 To use the `Matcher` you have to pass it to your renderer. For the `ListRenderer`,

--- a/doc/06-FAQ.md
+++ b/doc/06-FAQ.md
@@ -1,4 +1,4 @@
 FAQ
 ===
 
-* [How to apply the active class to a item and all ancestors](./examples/01_apply_active_class_to_whole_tree.md)
+* [How to apply the active class to an item and all ancestors](./examples/01_apply_active_class_to_whole_tree.md)

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,9 +7,13 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./src</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+    </listeners>
 </phpunit>

--- a/src/Knp/Menu/Iterator/CurrentItemFilterIterator.php
+++ b/src/Knp/Menu/Iterator/CurrentItemFilterIterator.php
@@ -24,6 +24,10 @@ class CurrentItemFilterIterator extends \FilterIterator
         parent::__construct($iterator);
     }
 
+    /**
+     * @return bool
+     */
+    #[\ReturnTypeWillChange]
     public function accept()
     {
         return $this->matcher->isCurrent($this->current());

--- a/src/Knp/Menu/Iterator/DisplayedItemFilterIterator.php
+++ b/src/Knp/Menu/Iterator/DisplayedItemFilterIterator.php
@@ -7,11 +7,19 @@ namespace Knp\Menu\Iterator;
  */
 class DisplayedItemFilterIterator extends \RecursiveFilterIterator
 {
+    /**
+     * @return bool
+     */
+    #[\ReturnTypeWillChange]
     public function accept()
     {
         return $this->current()->isDisplayed();
     }
 
+    /**
+     * @return bool
+     */
+    #[\ReturnTypeWillChange]
     public function hasChildren()
     {
         return $this->current()->getDisplayChildren() && parent::hasChildren();

--- a/src/Knp/Menu/Iterator/RecursiveItemIterator.php
+++ b/src/Knp/Menu/Iterator/RecursiveItemIterator.php
@@ -22,6 +22,10 @@ class RecursiveItemIterator extends \IteratorIterator implements \RecursiveItera
         return 0 < \count($this->current());
     }
 
+    /**
+     * @return \RecursiveIterator
+     */
+    #[\ReturnTypeWillChange]
     public function getChildren()
     {
         return new static($this->current());

--- a/src/Knp/Menu/Matcher/Voter/RouteVoter.php
+++ b/src/Knp/Menu/Matcher/Voter/RouteVoter.php
@@ -76,6 +76,11 @@ class RouteVoter implements VoterInterface
             throw new \InvalidArgumentException('Routes extra items must have a "route" or "pattern" key.');
         }
 
+        return $this->isMatchingParameters($request, $testedRoute) && $this->isMatchingQueryParameters($request, $testedRoute);
+    }
+
+    private function isMatchingParameters(Request $request, array $testedRoute): bool
+    {
         if (!isset($testedRoute['parameters'])) {
             return true;
         }
@@ -85,6 +90,24 @@ class RouteVoter implements VoterInterface
         foreach ($testedRoute['parameters'] as $name => $value) {
             // cast both to string so that we handle integer and other non-string parameters, but don't stumble on 0 == 'abc'.
             if (!isset($routeParameters[$name]) || (string) $routeParameters[$name] !== (string) $value) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function isMatchingQueryParameters(Request $request, array $testedRoute): bool
+    {
+        if (!isset($testedRoute['query_parameters'])) {
+            return true;
+        }
+
+        $routeQueryParameters = $request->query->all();
+
+        foreach ($testedRoute['query_parameters'] as $name => $value) {
+            // cast both to string so that we handle integer and other non-string parameters, but don't stumble on 0 == 'abc'.
+            if (!isset($routeQueryParameters[$name]) || (string) $routeQueryParameters[$name] !== (string) $value) {
                 return false;
             }
         }

--- a/src/Knp/Menu/MenuItem.php
+++ b/src/Knp/Menu/MenuItem.php
@@ -591,6 +591,7 @@ class MenuItem implements ItemInterface
      *
      * @return ItemInterface|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->getChild($offset);

--- a/tests/Knp/Menu/Tests/Integration/Symfony/RoutingExtensionTest.php
+++ b/tests/Knp/Menu/Tests/Integration/Symfony/RoutingExtensionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Knp\Menu\Tests\Silex;
+namespace Knp\Menu\Tests\Integration\Symfony;
 
 use Knp\Menu\Integration\Symfony\RoutingExtension;
 use PHPUnit\Framework\TestCase;

--- a/tests/Knp/Menu/Tests/Matcher/Voter/RouteVoterTest.php
+++ b/tests/Knp/Menu/Tests/Matcher/Voter/RouteVoterTest.php
@@ -46,10 +46,11 @@ final class RouteVoterTest extends TestCase
     /**
      * @param string|array<string, mixed> $itemRoutes
      * @param array<string, mixed>        $parameters
+     * @param array<string, mixed>        $queryParameters
      *
      * @dataProvider provideData
      */
-    public function testMatching(?string $route, array $parameters, $itemRoutes, ?bool $expected): void
+    public function testMatching(?string $route, array $parameters, array $queryParameters, $itemRoutes, ?bool $expected): void
     {
         $item = $this->getMockBuilder(ItemInterface::class)->getMock();
         $item->expects($this->any())
@@ -61,6 +62,7 @@ final class RouteVoterTest extends TestCase
         $request = new Request();
         $request->attributes->set('_route', $route);
         $request->attributes->set('_route_params', $parameters);
+        $request->query->add($queryParameters);
 
         $requestStack = new RequestStack();
         $requestStack->push($request);
@@ -79,17 +81,20 @@ final class RouteVoterTest extends TestCase
             'no request route' => [
                 null,
                 [],
+                [],
                 'foo',
                 null,
             ],
             'integer parameters' => [
                 'foo',
                 ['bar' => 128],
+                [],
                 [['route' => 'foo', 'parameters' => ['bar' => 128]]],
                 true,
             ],
             'no item route' => [
                 'foo',
+                [],
                 [],
                 null,
                 null,
@@ -97,11 +102,13 @@ final class RouteVoterTest extends TestCase
             'same single route' => [
                 'foo',
                 [],
+                [],
                 'foo',
                 true,
             ],
             'different single route' => [
                 'foo',
+                [],
                 [],
                 'bar',
                 null,
@@ -109,11 +116,13 @@ final class RouteVoterTest extends TestCase
             'matching multiple routes' => [
                 'foo',
                 [],
+                [],
                 ['foo', 'baz'],
                 true,
             ],
             'matching multiple routes 2' => [
                 'baz',
+                [],
                 [],
                 ['foo', 'baz'],
                 true,
@@ -121,42 +130,49 @@ final class RouteVoterTest extends TestCase
             'different multiple routes' => [
                 'foo',
                 [],
+                [],
                 ['bar', 'baz'],
                 null,
             ],
             'same single route with different parameters' => [
                 'foo',
                 ['1' => 'bar'],
+                [],
                 [['route' => 'foo', 'parameters' => ['1' => 'baz']]],
                 null,
             ],
             'same single route with same parameters' => [
                 'foo',
                 ['1' => 'bar'],
+                [],
                 [['route' => 'foo', 'parameters' => ['1' => 'bar']]],
                 true,
             ],
             'same single route with additional parameters' => [
                 'foo',
                 ['1' => 'bar'],
+                [],
                 [['route' => 'foo', 'parameters' => ['1' => 'bar', '2' => 'baz']]],
                 null,
             ],
             'same single route with less parameters' => [
                 'foo',
                 ['1' => 'bar', '2' => 'baz'],
+                [],
                 [['route' => 'foo', 'parameters' => ['1' => 'bar']]],
                 true,
             ],
             'same single route with different type parameters' => [
                 'foo',
                 ['1' => '2'],
+                [],
                 [['route' => 'foo', 'parameters' => ['1' => 2]]],
                 true,
             ],
             'same route with multiple route params' => [
                 'foo',
                 ['1' => 'bar'],
+                [],
                 [
                     ['route' => 'foo', 'parameters' => ['1' => 'baz']],
                     ['route' => 'foo', 'parameters' => ['1' => 'bar']],
@@ -166,6 +182,7 @@ final class RouteVoterTest extends TestCase
             'same route with and without route params' => [
                 'foo',
                 ['1' => 'bar'],
+                [],
                 [
                     ['route' => 'foo', 'parameters' => ['1' => 'baz']],
                     ['route' => 'foo'],
@@ -175,33 +192,94 @@ final class RouteVoterTest extends TestCase
             'same route with multiple different route params' => [
                 'foo',
                 ['1' => 'bar'],
+                [],
                 [
                     ['route' => 'foo', 'parameters' => ['1' => 'baz']],
                     ['route' => 'foo', 'parameters' => ['1' => 'foo']],
                 ],
                 null,
             ],
+            'same single route with different query parameters' => [
+                'foo',
+                [],
+                ['1' => 'bar'],
+                [['route' => 'foo', 'query_parameters' => ['1' => 'baz']]],
+                null,
+            ],
+            'same single route with same query parameters' => [
+                'foo',
+                [],
+                ['1' => 'bar'],
+                [['route' => 'foo', 'query_parameters' => ['1' => 'bar']]],
+                true,
+            ],
+            'same single route with additional query parameters' => [
+                'foo',
+                [],
+                ['1' => 'bar'],
+                [['route' => 'foo', 'query_parameters' => ['1' => 'bar', '2' => 'baz']]],
+                null,
+            ],
+            'same single route with less query parameters' => [
+                'foo',
+                [],
+                ['1' => 'bar', '2' => 'baz'],
+                [['route' => 'foo', 'query_parameters' => ['1' => 'bar']]],
+                true,
+            ],
+            'same single route with different parameters and different query parameters' => [
+                'foo',
+                ['1' => 'bar'],
+                ['2' => 'baz'],
+                [['route' => 'foo', 'parameters' => ['1' => 'baz'], 'query_parameters' => ['2' => 'bar']]],
+                null,
+            ],
+            'same single route with same parameters and different query parameters' => [
+                'foo',
+                ['1' => 'bar'],
+                ['2' => 'baz'],
+                [['route' => 'foo', 'parameters' => ['1' => 'bar'], 'query_parameters' => ['2' => 'bar']]],
+                null,
+            ],
+            'same single route with different parameters and same query parameters' => [
+                'foo',
+                ['1' => 'bar'],
+                ['2' => 'baz'],
+                [['route' => 'foo', 'parameters' => ['1' => 'baz'], 'query_parameters' => ['2' => 'baz']]],
+                null,
+            ],
+            'same single route with same parameters and same query parameters' => [
+                'foo',
+                ['1' => 'bar'],
+                ['2' => 'baz'],
+                [['route' => 'foo', 'parameters' => ['1' => 'bar'], 'query_parameters' => ['2' => 'baz']]],
+                true,
+            ],
             'matching pattern without parameters' => [
                 'foo',
                 ['1' => 'bar'],
+                [],
                 [['pattern' => '/fo/']],
                 true,
             ],
             'non matching pattern without parameters' => [
                 'foo',
                 ['1' => 'bar'],
+                [],
                 [['pattern' => '/bar/']],
                 null,
             ],
             'matching pattern with parameters' => [
                 'foo',
                 ['1' => 'bar'],
+                [],
                 [['pattern' => '/fo/', 'parameters' => ['1' => 'bar']]],
                 true,
             ],
             'matching pattern with different parameters' => [
                 'foo',
                 ['1' => 'bar'],
+                [],
                 [['pattern' => '/fo/', 'parameters' => ['1' => 'baz']]],
                 null,
             ],

--- a/tests/Knp/Menu/Tests/Provider/PsrProviderTest.php
+++ b/tests/Knp/Menu/Tests/Provider/PsrProviderTest.php
@@ -11,12 +11,16 @@ final class PsrProviderTest extends TestCase
 {
     public function testHas(): void
     {
-        $container = $this->prophesize(ContainerInterface::class);
-        $container->has('first')->willReturn(true);
-        $container->has('second')->willReturn(true);
-        $container->has('third')->willReturn(false);
+        $container = $this->createStub(ContainerInterface::class);
+        $container
+            ->method('has')
+            ->willReturnMap([
+                ['first', true],
+                ['second', true],
+                ['third', false],
+            ]);
 
-        $provider = new PsrProvider($container->reveal());
+        $provider = new PsrProvider($container);
         $this->assertTrue($provider->has('first'));
         $this->assertTrue($provider->has('second'));
         $this->assertFalse($provider->has('third'));
@@ -24,24 +28,34 @@ final class PsrProviderTest extends TestCase
 
     public function testGetExistentMenu(): void
     {
-        $menu = $this->prophesize(ItemInterface::class);
+        $menu = $this->createStub(ItemInterface::class);
 
-        $container = $this->prophesize(ContainerInterface::class);
-        $container->has('menu')->willReturn(true);
-        $container->get('menu')->willReturn($menu);
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->method('has')
+            ->with('menu')
+            ->willReturn(true);
+        $container
+            ->method('get')
+            ->with('menu')
+            ->willReturn($menu);
 
-        $provider = new PsrProvider($container->reveal());
-        $this->assertSame($menu->reveal(), $provider->get('menu'));
+        $provider = new PsrProvider($container);
+        $this->assertSame($menu, $provider->get('menu'));
     }
 
     public function testGetNonExistentMenu(): void
     {
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->method('has')
+            ->with('non-existent')
+            ->willReturn(false);
+
+        $provider = new PsrProvider($container);
+
         $this->expectException(\InvalidArgumentException::class);
 
-        $container = $this->prophesize(ContainerInterface::class);
-        $container->has('non-existent')->willReturn(false);
-
-        $provider = new PsrProvider($container->reveal());
         $provider->get('non-existent');
     }
 }

--- a/tests/Knp/Menu/Tests/Renderer/PsrProviderTest.php
+++ b/tests/Knp/Menu/Tests/Renderer/PsrProviderTest.php
@@ -11,12 +11,16 @@ final class PsrProviderTest extends TestCase
 {
     public function testHas(): void
     {
-        $container = $this->prophesize(ContainerInterface::class);
-        $container->has('first')->willReturn(true);
-        $container->has('second')->willReturn(true);
-        $container->has('third')->willReturn(false);
+        $container = $this->createStub(ContainerInterface::class);
+        $container
+            ->method('has')
+            ->willReturnMap([
+                ['first', true],
+                ['second', true],
+                ['third', false],
+            ]);
 
-        $provider = new PsrProvider($container->reveal(), 'first');
+        $provider = new PsrProvider($container, 'first');
         $this->assertTrue($provider->has('first'));
         $this->assertTrue($provider->has('second'));
         $this->assertFalse($provider->has('third'));
@@ -24,36 +28,52 @@ final class PsrProviderTest extends TestCase
 
     public function testGetExistentRenderer(): void
     {
-        $renderer = $this->prophesize(RendererInterface::class);
+        $renderer = $this->createStub(RendererInterface::class);
 
-        $container = $this->prophesize(ContainerInterface::class);
-        $container->has('renderer')->willReturn(true);
-        $container->get('renderer')->willReturn($renderer);
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->method('has')
+            ->with('renderer')
+            ->willReturn(true);
+        $container
+            ->method('get')
+            ->with('renderer')
+            ->willReturn($renderer);
 
-        $provider = new PsrProvider($container->reveal(), 'default');
-        $this->assertSame($renderer->reveal(), $provider->get('renderer'));
+        $provider = new PsrProvider($container, 'default');
+        $this->assertSame($renderer, $provider->get('renderer'));
     }
 
     public function testGetDefaultRenderer(): void
     {
-        $renderer = $this->prophesize(RendererInterface::class);
+        $renderer = $this->createStub(RendererInterface::class);
 
-        $container = $this->prophesize(ContainerInterface::class);
-        $container->has('default')->willReturn(true);
-        $container->get('default')->willReturn($renderer);
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->method('has')
+            ->with('default')
+            ->willReturn(true);
+        $container
+            ->method('get')
+            ->with('default')
+            ->willReturn($renderer);
 
-        $provider = new PsrProvider($container->reveal(), 'default');
-        $this->assertSame($renderer->reveal(), $provider->get());
+        $provider = new PsrProvider($container, 'default');
+        $this->assertSame($renderer, $provider->get());
     }
 
     public function testGetNonExistentRenderer(): void
     {
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->method('has')
+            ->with('non-existent')
+            ->willReturn(false);
+
+        $provider = new PsrProvider($container, 'default');
+
         $this->expectException(\InvalidArgumentException::class);
 
-        $container = $this->prophesize(ContainerInterface::class);
-        $container->has('non-existent')->willReturn(false);
-
-        $provider = new PsrProvider($container->reveal(), 'default');
         $provider->get('non-existent');
     }
 }


### PR DESCRIPTION
For case where query parameters are used to generate different pages.

For exemple:

- /tasks?state=open
- /tasks?state=done
- /tasks?state=archived
- ...